### PR TITLE
Add ignoreGestures Prop Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,3 @@ typings/
 
 # dotenv environment variables file
 .env
-
-# compiled files
-lib/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ interface UserInactivityProps<T = unknown> {
   isActive?: boolean;
 
   /**
+   * Prevents the PanResponder instance from being created so that user
+   * gestures are ignored and do not reset the timer.
+   * It defaults to false;
+   */
+  ignoreGestures?: boolean;
+
+  /**
    * Generic usetimeout-react-hook's TimeoutHandler implementation.
    * It defaults to the standard setTimeout/clearTimeout implementation.
    * See https://github.com/jkomyno/usetimeout-react-hook/#-how-to-use.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ interface UserInactivityProps<T = unknown> {
   /**
    * Prevents the PanResponder instance from being created so that user
    * gestures are ignored and do not reset the timer.
-   * It defaults to false;
+   * It defaults to false.
    */
   ignoreGestures?: boolean;
 

--- a/lib/BackgroundTimer.d.ts
+++ b/lib/BackgroundTimer.d.ts
@@ -1,0 +1,9 @@
+import { TimeoutHandler } from 'usetimeout-react-hook';
+/**
+ * defaultBackgroundTimer implements the TimeoutHandler interface with the native timer
+ * functions available in the 'react-native-background-timer' package.
+ * This timer works in foreground as well as background, and should overcome
+ * the standard setTimeout/clearTimeout shortcomings.
+ */
+export declare const defaultBackgroundTimer: TimeoutHandler<void>;
+export default defaultBackgroundTimer;

--- a/lib/BackgroundTimer.js
+++ b/lib/BackgroundTimer.js
@@ -1,0 +1,16 @@
+import BackgroundTimer from 'react-native-background-timer';
+/**
+ * defaultBackgroundTimer implements the TimeoutHandler interface with the native timer
+ * functions available in the 'react-native-background-timer' package.
+ * This timer works in foreground as well as background, and should overcome
+ * the standard setTimeout/clearTimeout shortcomings.
+ */
+export const defaultBackgroundTimer = {
+    clearTimeout: (_) => {
+        BackgroundTimer.stopBackgroundTimer();
+    },
+    setTimeout: (fn, timeout) => {
+        BackgroundTimer.runBackgroundTimer(fn, timeout);
+    },
+};
+export default defaultBackgroundTimer;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,7 @@
 import React from 'react';
-import { StyleProp, ViewStyle } from 'react-native';
+import { StyleProp, ViewProps, ViewStyle } from 'react-native';
 import { TimeoutHandler } from 'usetimeout-react-hook';
-export interface UserInactivityProps<T = unknown> {
+export interface UserInactivityProps<T = unknown> extends ViewProps {
     /**
      * Number of milliseconds after which the view is considered inactive.
      * If it changed, the timer restarts and the view is considered active until

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,55 @@
+import React from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
+import { TimeoutHandler } from 'usetimeout-react-hook';
+export interface UserInactivityProps<T = unknown> {
+    /**
+     * Number of milliseconds after which the view is considered inactive.
+     * If it changed, the timer restarts and the view is considered active until
+     * the new timer expires.
+     * It defaults to 1000.
+     */
+    timeForInactivity?: number;
+    /**
+     * If it's explicitly set to `true` after the component has already been initialized,
+     * the timer restarts and the view is considered active until the new timer expires.
+     * It defaults to true.
+     */
+    isActive?: boolean;
+    /**
+     * Prevents the PanResponder instance from being created so that user
+     * gestures are ignored and do not reset the timer.
+     * It defaults to false;
+     */
+    ignoreGestures?: boolean;
+    /**
+     * Generic usetimeout-react-hook's TimeoutHandler implementation.
+     * It defaults to the standard setTimeout/clearTimeout implementation.
+     * See https://github.com/jkomyno/usetimeout-react-hook/#-how-to-use.
+     */
+    timeoutHandler?: TimeoutHandler<T>;
+    /**
+     * Children components to embed inside UserInactivity's View.
+     * If any children component is pressed, `onAction` is called after
+     * `timeForInactivity` milliseconds.
+     */
+    children: React.ReactNode;
+    /**
+     * If set to true, the timer is not reset when the keyboard appears
+     * or disappears.
+     */
+    skipKeyboard?: boolean;
+    /**
+     * Optional custom style for UserInactivity's View.
+     * It defaults to { flex: 1 }.
+     */
+    style?: StyleProp<ViewStyle>;
+    /**
+     * Callback triggered anytime UserInactivity's View isn't touched for more than
+     * `timeForInactivity` seconds.
+     * It's `active` argument is true if and only if the View wasn't touched for more
+     * than `timeForInactivity` milliseconds.
+     */
+    onAction: (active: boolean) => void;
+}
+declare const _default: React.NamedExoticComponent<UserInactivityProps<unknown>>;
+export default _default;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,114 @@
+import React, { memo, useEffect, useRef, useState, } from 'react';
+import { Keyboard, PanResponder, View, } from 'react-native';
+import { defaultTimeoutHandler, useTimeout, } from 'usetimeout-react-hook';
+const defaultTimeForInactivity = 10000;
+const defaultStyle = {
+    flex: 1,
+};
+const UserInactivity = ({ children, isActive, ignoreGestures = false, onAction, skipKeyboard, style, timeForInactivity, timeoutHandler, }) => {
+    const actualStyle = style || defaultStyle;
+    /**
+     * If the user has provided a custom timeout handler, it is used directly,
+     * otherwise it defaults to the default timeout handler (setTimeout/clearTimeout).
+     */
+    const actualTimeoutHandler = timeoutHandler || defaultTimeoutHandler;
+    const timeout = timeForInactivity || defaultTimeForInactivity;
+    /**
+     * If the `isActive` prop is manually changed to `true`, call `resetTimerDueToActivity`
+     * to reset the timer and set the current state to active until the timeout expires.
+     * If the `isActive` is changed to `false`, nothing is done.
+     * Note however that toggling `isActive` manually is discouraged for normal use.
+     * It should only be used in those cases where React Native doesnt't seem to
+     * inform the `PanResponder` instance about touch events, such as when tapping
+     * over the keyboard.
+     */
+    const initialActive = isActive === undefined ? true : isActive;
+    const [active, setActive] = useState(initialActive);
+    useEffect(() => {
+        if (isActive) {
+            resetTimerDueToActivity();
+        }
+    }, [isActive]);
+    const [date, setDate] = useState(Date.now());
+    /**
+     * The timeout is reset when either `date` or `timeout` change.
+     */
+    const cancelTimer = useTimeout(() => {
+        setActive(false);
+        onAction(false);
+        // @ts-ignore
+    }, timeout, actualTimeoutHandler, [date, timeout]);
+    const isFirstRender = useRef(true);
+    /**
+     * Triggers `onAction` each time the `active` state turns true
+     * after the initial render.
+     */
+    useEffect(() => {
+        if (isFirstRender.current) {
+            isFirstRender.current = false;
+        }
+        else {
+            if (active) {
+                onAction(true);
+            }
+        }
+    }, [active]);
+    /**
+     * Resets the timer every time the keyboard appears or disappears,
+     * unless skipKeyboard is true.
+     */
+    useEffect(() => {
+        if (!skipKeyboard) {
+            Keyboard.addListener('keyboardDidHide', resetTimerDueToActivity);
+            Keyboard.addListener('keyboardDidShow', resetTimerDueToActivity);
+        }
+        // release event listeners on destruction
+        return () => {
+            if (!skipKeyboard) {
+                Keyboard.removeAllListeners('keyboardDidHide');
+                Keyboard.removeAllListeners('keyboardDidShow');
+            }
+        };
+    }, []);
+    /**
+     * This method is called whenever a touch is detected. If no touch is
+     * detected after `this.props.timeForInactivity` milliseconds, then
+     * `this.state.inactive` turns to true.
+     */
+    function resetTimerDueToActivity() {
+        cancelTimer();
+        setActive(true);
+        /**
+         * Causes `useTimeout` to restart.
+         */
+        setDate(Date.now());
+    }
+    /**
+     * In order not to steal any touches from the children components, this method
+     * must return false.
+     */
+    function resetTimerForPanResponder( /* event: GestureResponderEvent */) {
+        // const { identifier: touchID } = event.nativeEvent;
+        resetTimerDueToActivity();
+        return false;
+    }
+    /**
+     * The PanResponder instance.
+     */
+    const [panResponder, setPanResponder] = useState(ignoreGestures ? { panHandlers: {} } : PanResponder.create({
+        onMoveShouldSetPanResponderCapture: resetTimerForPanResponder,
+        onPanResponderTerminationRequest: resetTimerForPanResponder,
+        onStartShouldSetPanResponderCapture: resetTimerForPanResponder,
+    }));
+    useEffect(() => {
+        setPanResponder(ignoreGestures ? { panHandlers: {} } : PanResponder.create({
+            onMoveShouldSetPanResponderCapture: resetTimerForPanResponder,
+            onPanResponderTerminationRequest: resetTimerForPanResponder,
+            onStartShouldSetPanResponderCapture: resetTimerForPanResponder,
+        }));
+    }, [ignoreGestures]);
+    return (<View style={actualStyle} collapsable={false} {...panResponder.panHandlers}>
+      {children}
+    </View>);
+};
+export default memo(UserInactivity);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+import * as tslib_1 from "tslib";
 import React, { memo, useEffect, useRef, useState, } from 'react';
 import { Keyboard, PanResponder, View, } from 'react-native';
 import { defaultTimeoutHandler, useTimeout, } from 'usetimeout-react-hook';
@@ -5,7 +6,8 @@ const defaultTimeForInactivity = 10000;
 const defaultStyle = {
     flex: 1,
 };
-const UserInactivity = ({ children, isActive, ignoreGestures = false, onAction, skipKeyboard, style, timeForInactivity, timeoutHandler, }) => {
+const UserInactivity = (_a) => {
+    var { children, isActive, ignoreGestures = false, onAction, skipKeyboard, style, timeForInactivity, timeoutHandler } = _a, rest = tslib_1.__rest(_a, ["children", "isActive", "ignoreGestures", "onAction", "skipKeyboard", "style", "timeForInactivity", "timeoutHandler"]);
     const actualStyle = style || defaultStyle;
     /**
      * If the user has provided a custom timeout handler, it is used directly,
@@ -101,13 +103,15 @@ const UserInactivity = ({ children, isActive, ignoreGestures = false, onAction, 
         onStartShouldSetPanResponderCapture: resetTimerForPanResponder,
     }));
     useEffect(() => {
-        setPanResponder(ignoreGestures ? { panHandlers: {} } : PanResponder.create({
-            onMoveShouldSetPanResponderCapture: resetTimerForPanResponder,
-            onPanResponderTerminationRequest: resetTimerForPanResponder,
-            onStartShouldSetPanResponderCapture: resetTimerForPanResponder,
-        }));
+        if (!isFirstRender.current) {
+            setPanResponder(ignoreGestures ? { panHandlers: {} } : PanResponder.create({
+                onMoveShouldSetPanResponderCapture: resetTimerForPanResponder,
+                onPanResponderTerminationRequest: resetTimerForPanResponder,
+                onStartShouldSetPanResponderCapture: resetTimerForPanResponder,
+            }));
+        }
     }, [ignoreGestures]);
-    return (<View style={actualStyle} collapsable={false} {...panResponder.panHandlers}>
+    return (<View style={actualStyle} collapsable={false} {...rest} {...panResponder.panHandlers}>
       {children}
     </View>);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-user-inactivity",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,6 @@
   "dependencies": {
     "usetimeout-react-hook": "^0.1.2"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/mdaronco/react-native-user-inactivity"
-  },
   "devDependencies": {
     "@types/react": "^16.9.11",
     "@types/react-native": "^0.60.19",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "react-native-user-inactivity",
   "version": "1.1.0",
   "description": "React Native component that notifies if the user is active or not",
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "clean": "rimraf ./lib",
     "prebuild": "npm run clean && npm run lint",
@@ -11,11 +11,6 @@
     "build": "tsc",
     "lint": "tslint -c tslint.json -p tsconfig.json"
   },
-  "files": [
-    "lib",
-    "LICENSE",
-    "README.md"
-  ],
   "keywords": [
     "react",
     "react-native",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
   "dependencies": {
     "usetimeout-react-hook": "^0.1.2"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdaronco/react-native-user-inactivity"
+  },
   "devDependencies": {
     "@types/react": "^16.9.11",
     "@types/react-native": "^0.60.19",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,17 @@
 import React, {
+  FC,
   memo,
   useEffect,
   useRef,
   useState,
-  FC,
 } from 'react';
 import {
   Keyboard,
   PanResponder,
   StyleProp,
   View,
-  ViewStyle,
   ViewProps,
+  ViewStyle,
 } from 'react-native';
 import {
   defaultTimeoutHandler,
@@ -207,7 +207,7 @@ const UserInactivity: FC<UserInactivityProps> = ({
         onPanResponderTerminationRequest: resetTimerForPanResponder,
         onStartShouldSetPanResponderCapture: resetTimerForPanResponder,
       }));
-    } 
+    }
   }, [ignoreGestures]);
 
   return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import React, {
   useEffect,
   useRef,
   useState,
+  FC,
 } from 'react';
 import {
   Keyboard,
@@ -10,6 +11,7 @@ import {
   StyleProp,
   View,
   ViewStyle,
+  ViewProps,
 } from 'react-native';
 import {
   defaultTimeoutHandler,
@@ -22,7 +24,7 @@ const defaultStyle: ViewStyle = {
   flex: 1,
 };
 
-export interface UserInactivityProps<T = unknown> {
+export interface UserInactivityProps<T = unknown> extends ViewProps {
   /**
    * Number of milliseconds after which the view is considered inactive.
    * If it changed, the timer restarts and the view is considered active until
@@ -80,7 +82,7 @@ export interface UserInactivityProps<T = unknown> {
   onAction: (active: boolean) => void;
 }
 
-const UserInactivity: React.FC<UserInactivityProps> = ({
+const UserInactivity: FC<UserInactivityProps> = ({
   children,
   isActive,
   ignoreGestures = false,
@@ -89,6 +91,7 @@ const UserInactivity: React.FC<UserInactivityProps> = ({
   style,
   timeForInactivity,
   timeoutHandler,
+  ...rest
 }) => {
   const actualStyle = style || defaultStyle;
 
@@ -198,17 +201,20 @@ const UserInactivity: React.FC<UserInactivityProps> = ({
     }),
   );
   useEffect(() => {
-    setPanResponder(ignoreGestures ? { panHandlers: {} } : PanResponder.create({
-      onMoveShouldSetPanResponderCapture: resetTimerForPanResponder,
-      onPanResponderTerminationRequest: resetTimerForPanResponder,
-      onStartShouldSetPanResponderCapture: resetTimerForPanResponder,
-    }));
+    if (!isFirstRender.current) {
+      setPanResponder(ignoreGestures ? { panHandlers: {} } : PanResponder.create({
+        onMoveShouldSetPanResponderCapture: resetTimerForPanResponder,
+        onPanResponderTerminationRequest: resetTimerForPanResponder,
+        onStartShouldSetPanResponderCapture: resetTimerForPanResponder,
+      }));
+    } 
   }, [ignoreGestures]);
 
   return (
     <View
       style={actualStyle}
       collapsable={false}
+      {...rest}
       {...panResponder.panHandlers}
     >
       {children}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import React, {
+  memo,
   useEffect,
   useRef,
   useState,
@@ -38,6 +39,13 @@ export interface UserInactivityProps<T = unknown> {
   isActive?: boolean;
 
   /**
+   * Prevents the PanResponder instance from being created so that user
+   * gestures are ignored and do not reset the timer.
+   * It defaults to false;
+   */
+  ignoreGestures?: boolean;
+
+  /**
    * Generic usetimeout-react-hook's TimeoutHandler implementation.
    * It defaults to the standard setTimeout/clearTimeout implementation.
    * See https://github.com/jkomyno/usetimeout-react-hook/#-how-to-use.
@@ -75,6 +83,7 @@ export interface UserInactivityProps<T = unknown> {
 const UserInactivity: React.FC<UserInactivityProps> = ({
   children,
   isActive,
+  ignoreGestures = false,
   onAction,
   skipKeyboard,
   style,
@@ -179,15 +188,22 @@ const UserInactivity: React.FC<UserInactivityProps> = ({
   }
 
   /**
-   * The PanResponder instance is initialized only once.
+   * The PanResponder instance.
    */
-  const [panResponder, _] = useState(
-    PanResponder.create({
+  const [panResponder, setPanResponder] = useState(
+    ignoreGestures ? { panHandlers: {} } : PanResponder.create({
       onMoveShouldSetPanResponderCapture: resetTimerForPanResponder,
       onPanResponderTerminationRequest: resetTimerForPanResponder,
       onStartShouldSetPanResponderCapture: resetTimerForPanResponder,
     }),
   );
+  useEffect(() => {
+    setPanResponder(ignoreGestures ? { panHandlers: {} } : PanResponder.create({
+      onMoveShouldSetPanResponderCapture: resetTimerForPanResponder,
+      onPanResponderTerminationRequest: resetTimerForPanResponder,
+      onStartShouldSetPanResponderCapture: resetTimerForPanResponder,
+    }));
+  }, [ignoreGestures]);
 
   return (
     <View
@@ -200,4 +216,4 @@ const UserInactivity: React.FC<UserInactivityProps> = ({
   );
 };
 
-export default UserInactivity;
+export default memo(UserInactivity);


### PR DESCRIPTION
- Adds support for an optional `ignoreGestures` boolean prop that will prevent `PanResponder` pan handlers from being set on the `View`. This is suitable for use cases where we conditionally need to reset the timer based on user activity.
- Converts the FC to a pure component using the `memo` React HOC to prevent needless re-render cycles.
- Temporarily adding `lib/` to version control so that the `main` location exists 
- Updates `UserInactivityProps` to extend `ViewProps` for enhanced custom `View` control