### PR TITLE
Fix for Error: Attempted to remove more RTCKeyboardObserver Listeners than needed

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -139,16 +139,16 @@ const UserInactivity: React.FC<UserInactivityProps> = ({
    * unless skipKeyboard is true.
    */
   useEffect(() => {
+    let hideEvent, showEvent;
     if (!skipKeyboard) {
-      Keyboard.addListener('keyboardDidHide', resetTimerDueToActivity);
-      Keyboard.addListener('keyboardDidShow', resetTimerDueToActivity);
+      hideEvent = Keyboard.addListener('keyboardDidHide', resetTimerDueToActivity);
+      showEvent = Keyboard.addListener('keyboardDidShow', resetTimerDueToActivity);
     }
-
     // release event listeners on destruction
     return () => {
       if (!skipKeyboard) {
-        Keyboard.removeAllListeners('keyboardDidHide');
-        Keyboard.removeAllListeners('keyboardDidShow');
+        Keyboard.removeListener(hideEvent);
+        Keyboard.removeListener(showEvent);
       }
     };
   }, []);


### PR DESCRIPTION
This is proposal for fixing issue https://github.com/jkomyno/react-native-user-inactivity/issues/35

It simply stores event and remove only the one that is added, nothing more. This also get's rid of the issue (at least inside mine project).