### PR TITLE
Update README.md reflect common install issues with expo templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ than the standard one (`setTimeout`). This has solved some of the most recurrent
 ```sh
 npm install react-native-user-inactivity
 ```
+If you are running a version of react < 17 you'll need to include the `--legacy-peer-deps` flag.
+```sh
+npm install react-native-user-inactivity --legacy-peer-deps
+```
 
 ## 🔑 Key features
 


### PR DESCRIPTION
A lot of users seem to be trying to install this into a project using an expo template. (i.e. the created their repo using `expo init`) The current versions of these expo templates (as noted [here](https://github.com/expo/expo/blob/master/templates/expo-template-blank/package.json)) are using version 16 of react.

Because the react version requirement is 17 in npm many users are left with an error message when attempting to install this via npm, as noted [here](https://gitmemory.com/issue/jkomyno/react-native-user-inactivity/40/735009748).

a simple note in the documentation to use the `--legacy-peer-deps` flag will make this a lot clearer. 